### PR TITLE
add block labels and building foootprints

### DIFF
--- a/js/layerConfig.js
+++ b/js/layerConfig.js
@@ -3,7 +3,7 @@ const layerConfig = { // eslint-disable-line
     id: 'pluto',
     type: 'fill',
     source: 'pluto',
-    'source-layer': 'layer0',
+    'source-layer': 'pluto',
     paint: {
       'fill-color': 'rgba(81, 111, 217, 1)',
       'fill-opacity': 0.7,
@@ -14,20 +14,69 @@ const layerConfig = { // eslint-disable-line
   plutoLabels: {
     id: 'pluto-labels',
     type: 'symbol',
-    minzoom: 16,
     source: 'pluto',
-    'source-layer': 'layer0',
-    paint: {
-      'text-color': 'rgba(255, 255, 255, 1)',
-    },
+    'source-layer': 'pluto',
+    minzoom: 15,
     layout: {
-      'text-field': '{block}-{lot}',
+      'text-field': '{lot}',
       'text-font': [
         'Open Sans Regular',
         'Arial Unicode MS Regular',
       ],
       'text-size': 11,
     },
+    paint: {
+      'text-opacity': {
+        stops: [
+          [
+            15,
+            0,
+          ],
+          [
+            16,
+            1,
+          ],
+        ],
+      },
+      'icon-color': 'rgba(193, 193, 193, 1)',
+      'text-color': 'rgba(255, 255, 255, 1)',
+      'text-halo-color': 'rgba(152, 152, 152, 0)',
+    },
+  },
+
+  blockLabels: {
+    id: 'block-labels',
+    type: 'symbol',
+    source: 'pluto',
+    'source-layer': 'block-centroids',
+    minzoom: 14,
+    layout: {
+      'text-field': '{block}',
+      'text-font': [
+        'Open Sans Regular',
+        'Arial Unicode MS Regular',
+      ],
+      'text-size': 20,
+    },
+    paint: {
+      'text-halo-color': 'hsl(0, 0%, 100%)',
+      'text-halo-width': 1,
+      'text-color': 'rgba(121, 121, 121, 1)',
+      'text-halo-blur': 0,
+      'text-opacity': {
+        stops: [
+          [
+            14,
+            0,
+          ],
+          [
+            15,
+            1,
+          ],
+        ],
+      },
+    },
+    maxzoom: 24,
   },
 
   selectedLots: {

--- a/js/layerConfig.js
+++ b/js/layerConfig.js
@@ -50,16 +50,17 @@ const layerConfig = { // eslint-disable-line
     source: 'pluto',
     'source-layer': 'block-centroids',
     minzoom: 14,
+    maxzoom: 24,
     layout: {
       'text-field': '{block}',
       'text-font': [
-        'Open Sans Regular',
+        'Open Sans Bold',
         'Arial Unicode MS Regular',
       ],
-      'text-size': 20,
+      'text-size': 22,
     },
     paint: {
-      'text-halo-color': 'hsl(0, 0%, 100%)',
+      'text-halo-color': 'rgba(255, 255, 255, 0.5)',
       'text-halo-width': 1,
       'text-color': 'rgba(121, 121, 121, 1)',
       'text-halo-blur': 0,
@@ -76,7 +77,6 @@ const layerConfig = { // eslint-disable-line
         ],
       },
     },
-    maxzoom: 24,
   },
 
   selectedLots: {

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -113,14 +113,27 @@ map.on('load', function () {
 
   const mapConfig = {
     version: '1.3.0',
-    layers: [{
-      type: 'mapnik',
-      options: {
-        cartocss_version: '2.1.1',
-        cartocss: '#layer { polygon-fill: #FFF; }',
-        sql: 'SELECT cartodb_id, the_geom_webmercator, bbl, block, lot, address FROM support_mappluto',
+    layers: [
+      {
+        id: 'pluto',
+        type: 'mapnik',
+        options: {
+          cartocss_version: '2.1.1',
+          cartocss: '#layer { polygon-fill: #FFF; }',
+          sql: 'SELECT cartodb_id, the_geom_webmercator, bbl, block, lot, address FROM support_mappluto',
+        },
       },
-    }],
+      {
+        id: 'block-centroids',
+        type: 'mapnik',
+        options: {
+          cartocss_version: '2.1.1',
+          cartocss: '#layer { polygon-fill: #FFF; }',
+          sql: 'SELECT * FROM mappluto_block_centroids',
+        },
+      }
+
+    ],
   }
 
   Carto.getVectorTileTemplate(mapConfig, cartoOptions).then((tileTemplate) => {
@@ -134,10 +147,13 @@ map.on('load', function () {
        data: selectedLots
      });
 
-    map.addLayer(layerConfig.pluto, 'admin-2-boundaries-dispute');
+    map.addLayer(layerConfig.pluto, 'building');
     map.addLayer(layerConfig.plutoLabels);
+    map.addLayer(layerConfig.blockLabels);
     map.addLayer(layerConfig.selectedLots);
 
+    // set building layer opacity
+    map.setPaintProperty('building', 'fill-opacity', 0.2)
 
     // on click
     map.on('click', (e) => {
@@ -153,7 +169,7 @@ map.on('load', function () {
       if (features && features.length > 0) {
         const d = features[0].properties
         popup.setLngLat(e.lngLat)
-          .setHTML(d.address)
+          .setHTML(`${d.address}<br/>Block: ${d.block} Lot: ${d.lot}`)
           .addTo(map);
       } else {
         popup.remove();


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds large block labels to the map, and places the PLUTO layer behind building footprints (and makes the building footprints less opaque)

It also adds block and lot to the tooltip.

Closes #12 

