### PR TITLE
Fix the style link to make it actually load the map

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -9,7 +9,7 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiY3dob25nbnljIiwiYSI6ImNpczF1MXdrdjA4MXcycXA4Z
 /* eslint-disable */
 const map = new mapboxgl.Map({
     container: 'map', // container id
-    style: 'mapbox://styles/mapbox/light-v9', //hosted style id
+    style: '//raw.githubusercontent.com/NYCPlanning/labs-gl-style/master/data/style.json', //hosted style id
     center: [-73.98, 40.750768],
     zoom: 16,
     hash: true,


### PR DESCRIPTION
The current open source version does not work.
No map is shown.
This change corrects this issue.

This is the error you see, if you follow the instructions:

{"message":"Not Authorized - Invalid Token"}

Full trace:

GET /styles/v1/mapbox/light-v9?access_token=pk.eyJ1IjoiY3dob25nbnljIiwiYSI6ImNpczF1MXdrdjA4MXcycXA4ZGtyN2x5YXIifQ.3HGyME8tBs6BnljzUVIt4Q HTTP/1.1
Host: api.mapbox.com
Connection: keep-alive
Accept: application/json
Origin: http://localhost:8000
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Safari/537.36
Referer: http://localhost:8000/
Accept-Encoding: gzip, deflate, br
Accept-Language: en-US,en;q=0.9

{"message":"Not Authorized - Invalid Token"}

<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR {summarize the PR}

Changes Proposed:
- New Feature
- API change
- New Domain-specific language
- Refactor of existing code

Closes #{issue number(s)}
